### PR TITLE
fix post from newToilet.thml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/scripts/view/newToilets.js
+++ b/public/scripts/view/newToilets.js
@@ -19,14 +19,22 @@ function NewPooper(location, overallQuality, tpQuality, usage, occupancy, gender
 }
 
 NewPooper.prototype.insertRecord = function() {
-  $.post('/toilets', {location: this.location,
-                      overallQuality: this.overallQuality,
-                      tpQuality: this.tpQuality,
-                      usage: this.usage,
-                      occupancy: this.occupancy,
-                      genderNeutral: this.genderNeutral,
-                      drying: this.drying,
-                      comments: this.comments})
+  $.ajax({
+    url: '/toilets', 
+    method: 'POST',
+    dataType: 'json',
+    contentType: 'application/json; charset=utf-8',
+    data: JSON.stringify({
+      location: this.location,
+      overallQuality: this.overallQuality,
+      tpQuality: this.tpQuality,
+      usage: this.usage,
+      occupancy: this.occupancy,
+      genderNeutral: this.genderNeutral,
+      drying: this.drying,
+      comments: this.comments
+    })
+  })
   .then(console.log);
 };
 


### PR DESCRIPTION
Turns out the $.post will actually send url-encoded format, which is insane but explains why the server.js from class uses `bodyparser.urlencoded`. Anyway, here's how you can force jquery to send application/json format. Also, I gitignored your node_modules folder.